### PR TITLE
Add Jekyll SEO tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ gemspec
 
 gem 'jekyll'
 gem 'jekyll-paginate'
+gem 'jekyll-seo-tag'
 gem 'kramdown'
 gem 'pygments.rb'

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ author:
 # Gems
 gems:
   - jekyll-paginate
+  - jekyll-seo-tag
 
 #Others
 markdown: kramdown

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,4 +6,5 @@
   <link rel="stylesheet" href="{{ site.baseurl }}/css/normalize.css">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="{{ site.baseurl }}/css/cayman.css">
+  {% seo %}
 </head>


### PR DESCRIPTION
Uses Jekyll's SEO tag to make it easier to for search engines to index and find our org webpage.

ref: https://help.github.com/articles/search-engine-optimization-for-github-pages