### PR TITLE
Add `dask-imread` to the list

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 layout: default
 title: {{ site.name }}
 libraries:
+  - dask-imread
   - dask-ndfilters
   - dask-ndfourier
   - dask-ndinterp


### PR DESCRIPTION
Include `dask-imread` in the list of projects under the umbrella of the `dask-image` org. Make sure to link to the `dask-imread` repo from the webpage as well.